### PR TITLE
Fix code block detection

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -44,8 +44,9 @@ impl Parser {
             let mut line = line_result?;
             line = line.trim_end().to_string(); // remove trailing whitespace
 
-            // Check for triple-backtick line (open/close code block)
-            if line.trim() == "```" {
+            // Check for triple-backtick line (open/close code block). Allow
+            // optional language hints like "```rust".
+            if line.trim_start().starts_with("```") {
                 if in_code_block {
                     // Closing a code block
                     in_code_block = false;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -134,6 +134,37 @@ mod tests {
         assert!(output.contains("</code></pre>"), "Code block not closed properly");
     }
 
+    /// Test that code blocks with language markers are handled.
+    #[test]
+    fn test_format_to_markdown_code_block_with_language() {
+        let config = Config::default();
+        let formatter = Formatter::new(config);
+
+        let input = "```rust\nfn main() {}\n```";
+        let output = formatter
+            .format_to_markdown(Cursor::new(input))
+            .expect("Failed to format code block with language to Markdown");
+
+        assert!(output.contains("```\nfn main() {}"));
+        assert!(output.contains("```\n\n"));
+    }
+
+    /// Test that code blocks with language markers are handled in HTML output.
+    #[test]
+    fn test_format_to_html_code_block_with_language() {
+        let config = Config::default();
+        let formatter = Formatter::new(config);
+
+        let input = "```rust\nfn main() {}\n```";
+        let output = formatter
+            .format_to_html(Cursor::new(input))
+            .expect("Failed to format code block with language to HTML");
+
+        assert!(output.contains("<pre><code>"));
+        assert!(output.contains("fn main() {}"));
+        assert!(output.contains("</code></pre>"));
+    }
+
     /// Optional: Test custom Config variations if your parser handles them (e.g., removing extra spaces).
     #[test]
     fn test_custom_config() {


### PR DESCRIPTION
## Summary
- detect code blocks with language specifiers like ```rust
- add regression tests for language-specified code blocks

## Testing
- `cargo test --quiet` *(fails: failed to download from https://index.crates.io/config.json)*